### PR TITLE
Add 3 new template entries for API Management demos and create instructions for updating templates.json

### DIFF
--- a/.github/instructions/templates-json.instructions.md
+++ b/.github/instructions/templates-json.instructions.md
@@ -1,0 +1,134 @@
+---
+applyTo: 'static/templates.json'
+description: 'Authoritative instructions for updating static/templates.json entries using repo-mined metadata and strict validation'
+---
+
+# Templates Catalog Implementation Instructions
+
+These instructions govern adding and maintaining entries in `static/templates.json`. They define a deterministic process and validation rules.
+
+## Scope
+- File: `static/templates.json` (single JSON array of template objects)
+- Tags: must be from `src/data/tags.tsx` TagType union
+- Sources: A single GitHub repository per entry is the authoritative source for metadata
+
+## Contract: Template Entry Schema
+
+Fields and types:
+- title (string, required, unique)
+- description (string, required) - Ommit reference to bicep or AZD, it is the demo that we care about
+- preview (string, required) — relative path under `./templates/images/` or an absolute HTTPS URL
+- website (string, required) — author profile or project page
+- author (string, required)
+- source (string, required) — GitHub repo URL
+- demoguide (string, optional) — raw markdown URL
+- tags (string[], required) — each value must be in TagType
+- cost (string, required) — decimal as string (e.g., "3.00")
+- deploytime (string, required) — minutes as string (e.g., "5")
+- prereqs (string, optional) — raw markdown URL
+
+Conventions:
+- Keep keys in the order listed above
+- All fields are JSON strings except `tags` (array of strings)
+- Deduplicate and sort `tags` lexicographically for stable diffs
+- No trailing commas; entire file must be a single valid JSON array
+
+## Allowed Tags
+Authoritative allowed values are defined in `src/data/tags.tsx` (TagType). Do not invent new tags here—add to TagType first if necessary. Should contain a tag from the ILT course catalog.
+
+## Automation Workflow: From GitHub Repo to Entry
+
+When a user provides a GitHub repository URL, populate fields as follows:
+
+1. Discover metadata
+   - source: the provided repo URL
+   - website: repo owner profile URL (e.g., https://github.com/<owner>) or the repo homepage if defined
+   - author: repo owner display name if available; otherwise owner handle
+   - title: prefer a concise productized name from README H1; else repo name in human case
+   - description: first paragraph under README H1 (sanitize to one sentence, max ~240 chars)
+   - demoguide: README raw URL if it serves as the demo guide, or search for demoguide/*.md, docs/*guide*.md; use raw URL
+   - prereqs: search for prereqs.md or similar; use raw URL if present
+   - preview: look for images referenced in README (png/svg/jpg/webp). Prefer a repo `static/templates/images/` asset if already in our repo, else the first readable image in the repo via raw URL. If none, set `./templates/images/test.png`.
+
+2. Infer tags (best-effort, then human-confirm)
+   - Map keywords in README and repo topics to TagType values (e.g., aks → "aks", functions → "functions", apim → "apim", dotnet → "dotnet")
+   - Include certification tags if README or repo references AZ-*, AI-*, DP-*, SC-* codes
+   - Always validate against TagType; discard unknowns
+
+3. Ask user to confirm or adjust metadata
+   - Present all fields for review
+   - Allow user to edit title, description, tags, and URLs
+   - Ensure all required fields are filled
+
+4. Normalize & validate
+   - Deduplicate and sort tags
+   - Ensure required fields present and non-empty
+   - Validate URLs (https://)
+   - Keep cost/deploytime as strings
+
+5. Insert into `static/templates.json`
+   - Append as a new object near the end of the array
+   - Preserve formatting: no spaces for indentation; keep key order
+   - Do not reorder existing entries
+
+6. Status Report
+   - Report to the user in the chat the changes that were made. Assumptions, defaults and guesses that were made
+
+## JSON Schema (machine-validated)
+
+Place the following schema at `.copilot-tracking/schemas/templates.schema.json`. Treat it as reference for CI or external tooling; do not run validators or tests as part of this prompt-driven update.
+
+```json
+{
+   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/schemas/templates.schema.json",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "title",
+      "description",
+      "preview",
+      "website",
+      "author",
+      "source",
+      "tags",
+      "cost",
+      "deploytime"
+    ],
+    "additionalProperties": false,
+    "properties": {
+      "title": {"type": "string", "minLength": 3},
+      "description": {"type": "string", "minLength": 10},
+   "preview": {"type": "string", "pattern": "^(\\./templates/images/|https://)"},
+      "website": {"type": "string", "format": "uri", "pattern": "^https://"},
+      "author": {"type": "string", "minLength": 2},
+      "source": {"type": "string", "format": "uri", "pattern": "^https://github.com/"},
+      "demoguide": {"type": "string", "format": "uri", "pattern": "^https://"},
+      "tags": {
+        "type": "array",
+        "minItems": 1,
+        "items": {"type": "string"},
+        "uniqueItems": true
+      },
+      "cost": {"type": "string", "pattern": "^\\d+(\\.\\d{1,2})?$"},
+      "deploytime": {"type": "string", "pattern": "^\\d+$"},
+      "prereqs": {"type": "string", "format": "uri", "pattern": "^https://"}
+    }
+  }
+}
+```
+
+
+## Validation Checklist (pre-commit)
+- [ ] JSON parses; array only, no stray objects or trailing commas
+- [ ] Required fields present and non-empty
+- [ ] Tags are valid TagType, unique, sorted, Include at least 1 ILT course from tags
+- [ ] cost and deploytime are strings and match patterns
+- [ ] preview is repo image or local asset path
+- [ ] demoguide/prereqs raw URLs when present
+  
+- Note: Do not execute repo scripts or tests during this step; checks are manual/visual only.
+
+## Problem Resolution
+If metadata is missing from the repo, create a sensible placeholder and flag it in the PR description. Do not block insertion if the schema can be satisfied with defaults. Prefer updating the source repo later to improve fidelity.

--- a/.github/instructions/templates-json.instructions.md
+++ b/.github/instructions/templates-json.instructions.md
@@ -76,8 +76,6 @@ When a user provides a GitHub repository URL, populate fields as follows:
 
 ## JSON Schema (machine-validated)
 
-Place the following schema at `.copilot-tracking/schemas/templates.schema.json`. Treat it as reference for CI or external tooling; do not run validators or tests as part of this prompt-driven update.
-
 ```json
 {
    "$schema": "http://json-schema.org/draft-07/schema#",

--- a/.github/instructions/templates-json.instructions.md
+++ b/.github/instructions/templates-json.instructions.md
@@ -16,7 +16,7 @@ These instructions govern adding and maintaining entries in `static/templates.js
 
 Fields and types:
 - title (string, required, unique)
-- description (string, required) - Ommit reference to bicep or AZD, it is the demo that we care about
+- description (string, required) - Omit reference to bicep or AZD, it is the demo that we care about
 - preview (string, required) — relative path under `./templates/images/` or an absolute HTTPS URL
 - website (string, required) — author profile or project page
 - author (string, required)

--- a/.github/prompts/create-template-entry.prompt.md
+++ b/.github/prompts/create-template-entry.prompt.md
@@ -62,7 +62,7 @@ Use tools to gather the following from the repo:
 ## Validation
 - Ensure every new field is present and non-empty (except optional ones) and URLs are https.
 - Do not run any repository validation or test scripts (e.g., npm/yarn/pnpm tasks or schema validators). Produce the updated JSON only.
-- package.json is irrelevent it this task. 
+- package.json is irrelevant to this task. 
 
 ## Steps
 1. Read `static/templates.json` and `src/data/tags.tsx`.
@@ -72,7 +72,7 @@ Use tools to gather the following from the repo:
 5. Infer valid tags, dedupe, and sort.
 6. Construct the new object with the exact key order and defaults where required.
 7. Append to the existing array, preserving formatting (2 spaces) and order of existing entries.
-8. Output only the updated JSON array. The user is only insterested in the changes. Displaying the entire file is not necessary.
+8. Output only the updated JSON array. The user is only interested in the changes. Displaying the entire file is not necessary.
 9. Explain to the user any defaults, guesses, or assumptions made.
 
 ## Acceptance Criteria

--- a/.github/prompts/create-template-entry.prompt.md
+++ b/.github/prompts/create-template-entry.prompt.md
@@ -1,0 +1,99 @@
+---
+mode: 'agent'
+description: 'Research a GitHub repository and generate a complete entry for static/templates.json with validated fields and allowed tags.'
+applyTo: 'static/templates.json'
+tools: ['fetch', 'githubRepo', 'search', 'openSimpleBrowser', 'codebase', 'editFiles', 'runTasks', 'problems']
+---
+# Create Template Entry
+
+Your goal is to research the provided GitHub repository and append a complete, valid object to `static/templates.json`.
+
+## Inputs
+- ${input:RepoUrl} — A GitHub repository URL (e.g., https://github.com/OWNER/REPO)
+
+## Output
+- Updated `static/templates.json` content as a single JSON array including the newly appended object, preserving all existing entries and formatting no spaces, flush left. Output only JSON.
+
+## Constraints
+- The file is a single JSON array of objects; do not output any extra text.
+- Keys must appear in this exact order:
+  1. title
+  2. description
+  3. preview
+  4. website
+  5. author
+  6. source
+  7. demoguide (optional)
+  8. tags (array)
+  9. cost (string)
+  10. deploytime (string)
+  11. prereqs (optional)
+- Tags must match TagType values defined in `src/data/tags.tsx`.
+- Keep cost and deploytime as strings.
+- Ensure all URLs use https://.
+- Deduplicate and sort tags lexicographically.
+- Do not reorder existing entries.
+
+## Research Tasks
+Use tools to gather the following from the repo:
+1. README
+   - Title: H1 heading; if absent, humanize repo name
+   - Description: first non-empty paragraph under H1, single sentence, ≤ 240 chars rewritten to ignore references to Bicep or AZD. The demo is the focus.
+   - Images: first usable image (png/jpg/svg/webp); use raw URL for `preview`
+2. Repo metadata
+   - Owner page URL for `website`
+   - Owner handle or display name for `author`
+   - Topics and description text to help infer `tags`
+3. Demo and prerequisites
+   - `demoguide`: README raw URL or demoguide/*.md under main/master
+   - `prereqs`: prereqs.md under main/master when available
+4. Tag inference
+   - Map keywords (aks, functions, apim, app service, container apps, acr, aci, cosmos, storage, blob, event hub/grid, key vault, monitor, app insights, openai, azure ai, ml, front door, cdn, redis, vnet, vpn, sentinel, purview, traffic manager, firewall, bastion, app gateway, private endpoint/link, load balancer, dotnet, node, python, blazor) to TagType
+   - Should have 1 at least ILT course tag. Courses May be referenced in README or demo guide.
+   - Filter strictly to allowed TagType
+   - always have the "new" tag
+
+## Defaults (if missing)
+- preview: ./templates/images/test.png
+- cost: "3.00"
+- deploytime: "5"
+- tags: if none can be inferred, use ["new"]
+
+## Validation
+- Ensure every new field is present and non-empty (except optional ones) and URLs are https.
+- Do not run any repository validation or test scripts (e.g., npm/yarn/pnpm tasks or schema validators). Produce the updated JSON only.
+- package.json is irrelevent it this task. 
+
+## Steps
+1. Read `static/templates.json` and `src/data/tags.tsx`.
+2. Fetch README (main/master) and extract title, description, preview image.
+3. Query GitHub API for topics and owner details (use provided auth if available).
+4. Locate demoguide and prereqs files (prefer raw URLs).
+5. Infer valid tags, dedupe, and sort.
+6. Construct the new object with the exact key order and defaults where required.
+7. Append to the existing array, preserving formatting (2 spaces) and order of existing entries.
+8. Output only the updated JSON array. The user is only insterested in the changes. Displaying the entire file is not necessary.
+9. Explain to the user any defaults, guesses, or assumptions made.
+
+## Acceptance Criteria
+- The output is valid JSON and structurally consistent with the schema (no need to run validators or tests).
+- The new entry has unique title and required fields populated.
+- All tags are from TagType and sorted.
+- No reordering of existing entries and no trailing commas.
+
+## Example (structure only)
+```json
+{
+  "title": "...",
+  "description": "...",
+  "preview": "./templates/images/...png",
+  "website": "https://github.com/OWNER",
+  "author": "OWNER",
+  "source": "https://github.com/OWNER/REPO",
+  "demoguide": "https://raw.githubusercontent.com/OWNER/REPO/main/README.md",
+  "tags": ["az-204", "dotnet", "functions"],
+  "cost": "3.00",
+  "deploytime": "5",
+  "prereqs": "https://raw.githubusercontent.com/OWNER/REPO/main/prereqs.md"
+}
+```

--- a/.github/prompts/create-template-entry.prompt.md
+++ b/.github/prompts/create-template-entry.prompt.md
@@ -1,7 +1,6 @@
 ---
 mode: 'agent'
 description: 'Research a GitHub repository and generate a complete entry for static/templates.json with validated fields and allowed tags.'
-applyTo: 'static/templates.json'
 tools: ['fetch', 'githubRepo', 'search', 'openSimpleBrowser', 'codebase', 'editFiles', 'runTasks', 'problems']
 ---
 # Create Template Entry

--- a/static/templates.json
+++ b/static/templates.json
@@ -649,5 +649,41 @@
 "cost": "9.00",
 "deploytime": "15",    
 "prereqs": "https://raw.githubusercontent.com/true-while/pg-ai-azd/refs/heads/main/prereqs.md"
+},
+{
+"title": "Protect API Management with OAuth",
+"description": "A demo that shows how to secure an API in Azure API Management with OAuth, including Entra ID app registration examples.",
+"preview": "https://raw.githubusercontent.com/ronaldbosma/protect-apim-with-oauth/refs/heads/main/images/diagrams-overview.png",
+"website": "https://github.com/ronaldbosma",
+"author": "Ronald Bosma",
+"source": "https://github.com/ronaldbosma/protect-apim-with-oauth",
+"demoguide": "https://raw.githubusercontent.com/ronaldbosma/protect-apim-with-oauth/refs/heads/main/demos/demo.md",
+"tags": ["apim", "az-204", "loganalytics", "monitor", "new"],
+"cost": "3.00",
+  "deploytime": "4"
+},
+{
+"title": "Call API Management backend with OAuth",
+"description": "A demo that shows three ways to call OAuth-protected APIs through API Management: Credential Manager, send-request with client secret, and send-request with client certificate.",
+"preview": "https://raw.githubusercontent.com/ronaldbosma/call-apim-backend-with-oauth/refs/heads/main/images/diagrams-overview.png",
+"website": "https://github.com/ronaldbosma",
+"author": "Ronald Bosma",
+"source": "https://github.com/ronaldbosma/call-apim-backend-with-oauth",
+"demoguide": "https://raw.githubusercontent.com/ronaldbosma/call-apim-backend-with-oauth/refs/heads/main/demos/demo.md",
+"tags": ["apim", "az-204", "keyvault", "loganalytics", "new"],
+"cost": "3.00",
+"deploytime": "4"
+},
+{
+"title": "Call API Management with Managed Identity",
+"description": "Demonstrates calling Azure API Management from Azure Functions and Logic Apps using managed identities with OAuth, including one APIM API securely calling another without secrets.",
+"preview": "https://raw.githubusercontent.com/ronaldbosma/call-apim-with-managed-identity/refs/heads/main/images/diagrams-overview.png",
+"website": "https://github.com/ronaldbosma",
+"author": "Ronald Bosma",
+"source": "https://github.com/ronaldbosma/call-apim-with-managed-identity",
+"demoguide": "https://raw.githubusercontent.com/ronaldbosma/call-apim-with-managed-identity/refs/heads/main/demos/demo.md",
+"tags": ["apim", "appinsights", "az-204", "functions", "logicapps", "new"],
+"cost": "3.00",
+"deploytime": "7"
 }
 ]


### PR DESCRIPTION
templates-json.instructions.md: Source of truth for schema, tags, defaults, validation, and how to append entries to static/templates.json.

create-template-entry.prompt.md: Operational checklist for researching a GitHub repo and producing a compliant object (fields order, defaults, tagging rules).