### PR TITLE
Add template: Track Availability in Application Insights using Standard Test, Azure Function and Logic App Workflow

### DIFF
--- a/static/templates.json
+++ b/static/templates.json
@@ -821,6 +821,6 @@
   "tags": ["az-204", "az-305", "appinsights", "dotnet", "functions", "logicapps", "monitor"],
   "cost": "8.00",
   "deploytime": "10",    
-  "prereqs": "https://raw.githubusercontent.com/ronaldbosma/track-availability-in-app-insights/refs/heads/main/README.md"
+  "prereqs": "https://raw.githubusercontent.com/ronaldbosma/track-availability-in-app-insights/refs/heads/main/prereqs.md"
   }
 ]


### PR DESCRIPTION
Adds the template [Track Availability in Application Insights using Standard Test, Azure Function and Logic App Workflow](https://github.com/ronaldbosma/track-availability-in-app-insights).

See [this PR](https://github.com/ronaldbosma/track-availability-in-app-insights/pull/22) for the changes I made to the template to prepare it.