### PR TITLE
feat(gallery): add private-foundry-aks-apim-afd scenario

### DIFF
--- a/static/templates.json
+++ b/static/templates.json
@@ -906,5 +906,17 @@
   "demoguide": "https://raw.githubusercontent.com/petender/tdd-azd-foundry-healthcare-agents/refs/heads/main/demoguide/demoguide.md",
   "deploytime": "8",
   "cost": "15.00"
+  },
+  {
+  "title": "Private Foundry + AKS + APIM + Azure Front Door",
+  "description": "Progressive network-security demo showcasing 4 stages of hardening an AI chat workload: from direct AKS access through APIM public/private to full Azure Front Door + Private APIM production architecture.",
+  "preview": "./templates/images/private-foundry-aks-apim-afd.png",
+  "author": "Peter De Tender",
+  "website": "https://github.com/petender",
+  "source": "https://github.com/petender/tdd-azd-private-foundry-aks-apim-afd",
+  "tags": ["az-500", "az-700", "msft", "aks", "apim", "frontdoor", "aifoundry", "acr", "keyvault", "bastion", "vnets", "privateendpoint", "dotnet", "kubernetes"],
+  "demoguide": null,
+  "deploytime": "15",
+  "cost": "25.00"
   }
 ]

--- a/static/templates.json
+++ b/static/templates.json
@@ -911,12 +911,12 @@
   {
   "title": "Private Foundry + AKS + APIM + Azure Front Door",
   "description": "Progressive network-security demo showcasing 4 stages of hardening an AI chat workload: from direct AKS access through APIM public/private to full Azure Front Door + Private APIM production architecture.",
-  "preview": "./templates/images/private-foundry-aks-apim-afd.png",
-  "author": "Peter De Tender",
+  "preview": "https://raw.githubusercontent.com/petender/tdd-azd-private-foundry-aks-apim-afd/refs/heads/main/demoguide/images/resource-group-overview.png",
   "website": "https://github.com/petender",
+  "author": "Peter De Tender",
   "source": "https://github.com/petender/tdd-azd-private-foundry-aks-apim-afd",
-  "tags": ["az-500", "az-700", "msft", "aks", "apim", "frontdoor", "aifoundry", "acr", "keyvault", "bastion", "vnets", "privateendpoint", "dotnet", "kubernetes"],
   "demoguide": "https://raw.githubusercontent.com/petender/tdd-azd-private-foundry-aks-apim-afd/refs/heads/main/demoguide/demoguide.md",
+  "tags": ["acr", "aifoundry", "aks", "apim", "az-500", "az-700", "bastion", "dotnet", "frontdoor", "keyvault", "kubernetes", "msft", "privateendpoint", "vnets"],
   "deploytime": "15",
   "cost": "25.00"
   },

--- a/static/templates.json
+++ b/static/templates.json
@@ -916,7 +916,7 @@
   "website": "https://github.com/petender",
   "source": "https://github.com/petender/tdd-azd-private-foundry-aks-apim-afd",
   "tags": ["az-500", "az-700", "msft", "aks", "apim", "frontdoor", "aifoundry", "acr", "keyvault", "bastion", "vnets", "privateendpoint", "dotnet", "kubernetes"],
-  "demoguide": null,
+  "demoguide": "https://raw.githubusercontent.com/petender/tdd-azd-private-foundry-aks-apim-afd/refs/heads/main/demoguide/demoguide.md",
   "deploytime": "15",
   "cost": "25.00"
   },

--- a/static/templates.json
+++ b/static/templates.json
@@ -909,6 +909,18 @@
   "cost": "15.00"
   },
   {
+  "title": "Private Foundry + AKS + APIM + Azure Front Door",
+  "description": "Progressive network-security demo showcasing 4 stages of hardening an AI chat workload: from direct AKS access through APIM public/private to full Azure Front Door + Private APIM production architecture.",
+  "preview": "./templates/images/private-foundry-aks-apim-afd.png",
+  "author": "Peter De Tender",
+  "website": "https://github.com/petender",
+  "source": "https://github.com/petender/tdd-azd-private-foundry-aks-apim-afd",
+  "tags": ["az-500", "az-700", "msft", "aks", "apim", "frontdoor", "aifoundry", "acr", "keyvault", "bastion", "vnets", "privateendpoint", "dotnet", "kubernetes"],
+  "demoguide": null,
+  "deploytime": "15",
+  "cost": "25.00"
+  },
+  {
   "title": "App Service with Azure SQL - Finance PaaS",
   "description": "Fully PaaS finance portfolio demo with App Service, Azure SQL Database, Key Vault, and Application Insights for mid-market financial services.",
   "preview": "./templates/images/appservice-sql-paas.png",


### PR DESCRIPTION
## New Template Registration

| Field       | Value |
|-------------|-------|
| Scenario    | private-foundry-aks-apim-afd |
| Repo        | [petender/tdd-azd-private-foundry-aks-apim-afd](https://github.com/petender/tdd-azd-private-foundry-aks-apim-afd) |
| Tags        | az-500, az-700, aks, apim, frontdoor, aifoundry, acr, keyvault, bastion, vnets, privateendpoint, dotnet, kubernetes |
| Sample App  | Yes (.NET Razor Pages chat frontend) |
| Contributor | @petender |

### Tag Validation

All tags validated against `src/data/tags.tsx` TagType union: :white_check_mark: PASSED

### What's in the standalone repo

- `infra/` — Bicep templates (11 modules: AKS, APIM, AFD, Foundry, ACR, Key Vault, Bastion, Jump VM, Networking, Log Analytics, Role Assignments)
- `k8s/` — Kubernetes deployment manifests
- `azure.yaml` — azd project configuration
- `README.md` — Quickstart deployment instructions
- `src/` — .NET chat frontend (FoundryChat.Web)

### Deployment

```bash
gh repo clone petender/tdd-azd-private-foundry-aks-apim-afd
cd tdd-azd-private-foundry-aks-apim-afd
azd init
azd up
```

### Reviewer Checklist

- [ ] Verify standalone repo is accessible
- [ ] All tags are valid TagType values
- [ ] Run `azd up` in a test subscription
- [ ] Review demo guide for accuracy
- [ ] Merge this gallery entry