### PR TITLE
feat(gallery): add azure-network-manager-demo scenario

### DIFF
--- a/static/templates.json
+++ b/static/templates.json
@@ -906,5 +906,17 @@
   "demoguide": "https://raw.githubusercontent.com/petender/tdd-azd-foundry-healthcare-agents/refs/heads/main/demoguide/demoguide.md",
   "deploytime": "8",
   "cost": "15.00"
+  }  ,
+  {
+  "title": "Azure Virtual Network Manager",
+  "description": "Demonstrates Azure Virtual Network Manager for multi-region hub-spoke and mesh topologies with centralized security admin rules and dynamic network groups.",
+  "preview": "./templates/images/azure-network-manager-demo.png",
+  "author": "Peter De Tender",
+  "website": "https://github.com/petender",
+  "source": "https://github.com/petender/tdd-azd-azure-network-manager-demo",
+  "tags": ["az-700","az-104","msft","vnets","bastion","virtualmachine","loganalytics"],
+  "demoguide": "https://raw.githubusercontent.com/petender/tdd-azd-azure-network-manager-demo/refs/heads/main/demoguide/demoguide.md",
+  "deploytime": "8",
+  "cost": "10.00"
   }
 ]

--- a/static/templates.json
+++ b/static/templates.json
@@ -946,6 +946,18 @@
   "cost": "12.00"
   },
   {
+  "title": "Azure Virtual Network Manager",
+  "description": "Demonstrates Azure Virtual Network Manager for multi-region hub-spoke and mesh topologies with centralized security admin rules and dynamic network groups.",
+  "preview": "./templates/images/azure-network-manager-demo.png",
+  "author": "Peter De Tender",
+  "website": "https://github.com/petender",
+  "source": "https://github.com/petender/tdd-azd-azure-network-manager-demo",
+  "tags": ["az-700","az-104","msft","vnets","bastion","virtualmachine","loganalytics"],
+  "demoguide": "https://raw.githubusercontent.com/petender/tdd-azd-azure-network-manager-demo/refs/heads/main/demoguide/demoguide.md",
+  "deploytime": "8",
+  "cost": "10.00"
+  },
+  {
   "title": "Linux VM with SSH and NSG",
   "description": "Foundational IaaS scenario with Ubuntu VM, VNet, NSG SSH inbound rule, Public IP, and Log Analytics for Azure VM deployment and network security.",
   "preview": "./templates/images/linux-vm-ssh-nsg.png",


### PR DESCRIPTION
## New Template Registration

| Field | Value |
|-------|-------|
| Scenario | azure-network-manager-demo |
| Repo | [petender/tdd-azd-azure-network-manager-demo](https://github.com/petender/tdd-azd-azure-network-manager-demo) |
| Tags | az-700,az-104,msft,vnets,bastion,virtualmachine,loganalytics |
| Sample App | No |
| Demo Guide | Yes |
| Contributor | @petender |

### Tag Validation
All tags validated against src/data/tags.tsx TagType union: :white_check_mark: PASSED

### Deployment
`
gh repo clone petender/tdd-azd-azure-network-manager-demo
cd tdd-azd-azure-network-manager-demo
azd init
azd up
`