### PR TITLE
feat(site): Rename Orchestrator → Conductor and update repo references

### DIFF
--- a/site/src/components/orchestrator-preview/Transcript.astro
+++ b/site/src/components/orchestrator-preview/Transcript.astro
@@ -33,7 +33,7 @@ const placeholder = "Describe what to build";
   data-opx-carousel-mode={carouselMode ? "1" : "0"}
   class="opx-transcript relative flex h-[600px] flex-col overflow-hidden rounded-xl border border-neutral-800 bg-[#1b1c20] text-neutral-100 shadow-2xl"
   role="region"
-  aria-label={`Orchestrator preview: ${meta.title}`}
+  aria-label={`Conductor preview: ${meta.title}`}
 >
   {/* Tab strip — VS Code-style "CHAT" tab with thin accent underline + window controls. */}
   <div class="flex items-center px-3 pt-2 pb-0">

--- a/site/src/lib/opx.test.ts
+++ b/site/src/lib/opx.test.ts
@@ -33,7 +33,7 @@ describe("parseOpx — happy path", () => {
 
   it("applies defaults for optional meta fields", () => {
     const out = parseOpx(validScript());
-    expect(out.meta.agent).toBe("orchestrator");
+    expect(out.meta.agent).toBe("Conductor");
     expect(out.meta.loop).toBe(true);
     expect(out.meta.startDelay).toBe(400);
   });

--- a/site/src/lib/opx.ts
+++ b/site/src/lib/opx.ts
@@ -169,7 +169,7 @@ const MetaSchema = z
   .object({
     id: z.string().min(1),
     title: z.string().min(1),
-    agent: z.string().default("orchestrator"),
+    agent: z.string().default("Conductor"),
     model: z.string().default("Claude Opus 4.7"),
     context: z.string().default(""),
     task: TaskSchema,

--- a/site/src/pages/byod-azure.astro
+++ b/site/src/pages/byod-azure.astro
@@ -29,7 +29,7 @@ const examples = [
 ---
 <Base
   title="BYOD · Azure"
-  description="Describe an Azure workload and let the orchestrator scaffold Bicep, application code, and a trainer demo guide end-to-end."
+  description="Describe an Azure workload and let the Conductor scaffold Bicep, application code, and a trainer demo guide end-to-end."
 >
   <section class="relative overflow-hidden">
     <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10">

--- a/site/src/pages/contribute.astro
+++ b/site/src/pages/contribute.astro
@@ -6,8 +6,8 @@ const steps = [
   {
     n: "01",
     title: "Create your template",
-    body: "Start from the starter so you get the right structure out of the box.",
-    code: "azd init -t petender/tdd-azd-starter",
+    body: "Start from this repo so you get the right structure out of the box.",
+    code: "git clone https://github.com/MicrosoftLearning/trainer-demo-deploy",
     bullets: [
       "Complete file structure with helpful placeholders",
       "Example Bicep infrastructure patterns",
@@ -36,7 +36,7 @@ const steps = [
   {
     n: "03",
     title: "Publish to GitHub",
-    body: "Create a public GitHub repository and push your template. The repo name should match your template name in azure.yaml (e.g., tdd-my-scenario). See publishing instructions in the starter's CONTRIBUTING.md.",
+    body: "Create a public GitHub repository and push your template. The repo name should match your template name in azure.yaml (e.g., tdd-my-scenario). See publishing instructions in CONTRIBUTING.md.",
   },
   {
     n: "04",
@@ -69,6 +69,37 @@ const steps = [
         Your scenarios help the entire Microsoft training community deliver better technical instruction.
       </p>
     </div>
+  </section>
+
+  <!-- Getting started: agentic workflow -->
+  <section class="max-w-5xl mx-auto px-6 pb-16">
+    <h2 class="text-2xl font-semibold mb-2">Getting started</h2>
+    <p class="text-sm text-neutral-600 dark:text-neutral-300 mb-6">
+      The fastest path from idea to deployable demo — let the Conductor build it for you.
+    </p>
+    <ol class="space-y-4">
+      <li class="flex items-start gap-4 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5">
+        <div class="shrink-0 w-9 h-9 rounded-lg bg-gradient-to-br from-[#8661c5] to-[#0078D4] text-white font-mono text-sm flex items-center justify-center font-semibold">1</div>
+        <div>
+          <div class="font-semibold mb-0.5">Fork the repo</div>
+          <p class="text-sm text-neutral-700 dark:text-neutral-300">Fork <a class="text-[#0078D4] dark:text-[#C5B4E3] underline underline-offset-2" href="https://github.com/MicrosoftLearning/trainer-demo-deploy" target="_blank" rel="noopener">MicrosoftLearning/trainer-demo-deploy</a> to your GitHub account and clone it locally.</p>
+        </div>
+      </li>
+      <li class="flex items-start gap-4 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5">
+        <div class="shrink-0 w-9 h-9 rounded-lg bg-gradient-to-br from-[#8661c5] to-[#0078D4] text-white font-mono text-sm flex items-center justify-center font-semibold">2</div>
+        <div>
+          <div class="font-semibold mb-0.5">Open in VS Code and start a Chat</div>
+          <p class="text-sm text-neutral-700 dark:text-neutral-300">Open the repo folder in VS Code, then open Copilot Chat (<kbd class="px-1.5 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 text-[0.85em] font-mono">Ctrl+Shift+I</kbd>).</p>
+        </div>
+      </li>
+      <li class="flex items-start gap-4 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5">
+        <div class="shrink-0 w-9 h-9 rounded-lg bg-gradient-to-br from-[#8661c5] to-[#0078D4] text-white font-mono text-sm flex items-center justify-center font-semibold">3</div>
+        <div>
+          <div class="font-semibold mb-0.5">Select the <code class="px-1 rounded bg-neutral-100 dark:bg-neutral-800 text-[0.9em]">01-conductor</code> agent</div>
+          <p class="text-sm text-neutral-700 dark:text-neutral-300">Pick <strong>01-conductor</strong> from the agent dropdown and describe your demo scenario. The Conductor handles the rest.</p>
+        </div>
+      </li>
+    </ol>
   </section>
 
   <!-- 4-step quick start -->
@@ -186,7 +217,7 @@ const steps = [
     </ol>
     <p class="mt-3 text-neutral-700 dark:text-neutral-300 leading-relaxed">
       The <a class="text-[#0078D4] dark:text-[#C5B4E3] underline underline-offset-2"
-             href="https://github.com/petender/tdd-azd-starter" target="_blank" rel="noopener">starter template</a>
+             href="https://github.com/MicrosoftLearning/trainer-demo-deploy" target="_blank" rel="noopener">this repo</a>
       shows the expected structure.
     </p>
   </section>

--- a/site/src/pages/faq.astro
+++ b/site/src/pages/faq.astro
@@ -150,8 +150,8 @@ const sections = [
             There are a few different ways to create azd templates, depending on your starting point. If you want to provide a full
             demo scenario for Trainer-Demo-Deploy, use the
             <a class="text-[#0078D4] dark:text-[#C5B4E3] underline underline-offset-2"
-               href="https://github.com/petender/tdd-azd-starter" target="_blank" rel="noopener">tdd-azd-starter</a>
-            template, which contains the following structure:
+               href="https://github.com/MicrosoftLearning/trainer-demo-deploy" target="_blank" rel="noopener">trainer-demo-deploy</a>
+            repo, which contains the following structure:
           </p>
 <pre class="mt-3 rounded-md bg-neutral-900 text-neutral-100 p-4 overflow-x-auto text-xs leading-relaxed"><code>├── .devcontainer              [ For DevContainer ]
 ├── demoguide                  [ demoguide.md + screenshots ]

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -37,7 +37,7 @@ const galleryHref = withBase("gallery/");
         <p class="mt-5 max-w-xl text-[15px] leading-relaxed text-neutral-700 dark:text-neutral-300">
           A trainer-first catalog of azd templates and bring-your-own-demo
           scaffolds. Browse curated scenarios, or describe a demo and let the
-          orchestrator scaffold the infra, code, and demo guide for you.
+          Conductor scaffold the infra, code, and demo guide for you.
         </p>
 
         <div class="mt-7 flex flex-wrap items-center gap-3">

--- a/site/src/scripts/byod-azure-aca.opx.yaml
+++ b/site/src/scripts/byod-azure-aca.opx.yaml
@@ -1,7 +1,7 @@
 meta:
   id: byod-azure-aca
   title: "Trainer Demo Deploy — BYOD Azure scaffold"
-  agent: orchestrator
+  agent: Conductor
   model: "Claude Opus 4.7"
   context: "BYOD Azure — AI-200 Container Apps"
   task:

--- a/site/src/scripts/byod-cps-it-triage.opx.yaml
+++ b/site/src/scripts/byod-cps-it-triage.opx.yaml
@@ -1,7 +1,7 @@
 meta:
   id: byod-cps-it-triage
   title: "Trainer Demo Deploy — BYOD Copilot Studio scaffold"
-  agent: orchestrator
+  agent: Conductor
   model: "Claude Opus 4.7"
   context: "BYOD Copilot Studio — MS-4006"
   task:

--- a/site/src/scripts/opx-stress-test.opx.yaml
+++ b/site/src/scripts/opx-stress-test.opx.yaml
@@ -1,7 +1,7 @@
 meta:
   id: opx-stress-test
   title: "OPX STRESS TEST — every step kind & feature"
-  agent: orchestrator
+  agent: Conductor
   model: "Claude Opus 4.7"
   context: "Schema smoke test"
   task:


### PR DESCRIPTION
## Summary

Two sets of changes for the new deployment:

### 1. Agent rename: Orchestrator → Conductor

Updated all user-visible labels in `site/src/` (no component or folder renames):
- `Transcript.astro` aria-label
- `index.astro` hero paragraph
- `byod-azure.astro` page meta description
- `opx.ts` default agent name
- All 3 OPX yaml scripts
- `opx.test.ts` assertion

### 2. Repo references: petender/tdd-azd-starter → MicrosoftLearning/trainer-demo-deploy

Contributors now pull from THIS repo:
- `contribute.astro` — clone command, body text, and "Already have a template?" link
- `faq.astro` — "How do I create templates?" link

### 3. Added Getting Started section

New agentic workflow quick-start on the Contribute page:
1. Fork the repo
2. Open in VS Code, open Chat
3. Select `01-conductor` — done

Only `site/src/` files were modified (legacy `/src/` app untouched).