### PR TITLE
Add GitHub stars to catalog cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "test": "jest"
+    "test": "jest",
+    "fetch-stars": "node scripts/fetch-stars.js"
+
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/scripts/fetch-stars.js
+++ b/scripts/fetch-stars.js
@@ -1,0 +1,87 @@
+const fs = require("fs");
+const path = require("path");
+
+const templatesPath = path.join(__dirname, "../static/templates.json");
+const outputPath = path.join(__dirname, "../static/scenario-stars.json");
+
+const templates = JSON.parse(fs.readFileSync(templatesPath, "utf-8"));
+
+function getRepoSlug(url) {
+  if (!url) return null;
+
+  const match = url.match(/github\.com\/([^/]+)\/([^/?#]+)/i);
+
+  if (!match) return null;
+
+  return {
+    owner: match[1],
+    repo: match[2].replace(".git", ""),
+  };
+}
+
+async function fetchStars(owner, repo) {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}`,
+    { headers }
+  );
+
+  if (!response.ok) {
+    console.log(
+      `Failed: ${owner}/${repo} - ${response.status} ${response.statusText}`
+    );
+    return null;
+  }
+
+  const data = await response.json();
+  return data.stargazers_count;
+}
+
+async function main() {
+  if (!process.env.GITHUB_TOKEN) {
+    console.warn(
+      "Warning: No GITHUB_TOKEN provided. GitHub API rate limits may apply."
+    );
+  }
+
+  const result = {};
+
+  for (const template of templates) {
+    if (!template.source) continue;
+
+    const repoInfo = getRepoSlug(template.source);
+
+    if (!repoInfo) continue;
+
+    const stars = await fetchStars(repoInfo.owner, repoInfo.repo);
+
+    if (stars !== null) {
+      result[template.source] = {
+        stars,
+      };
+
+      console.log(`${repoInfo.owner}/${repoInfo.repo} : ${stars}`);
+    }
+  }
+
+  if (Object.keys(result).length === 0) {
+    console.log(
+      "No stars fetched. Keeping existing scenario-stars.json unchanged."
+    );
+    return;
+  }
+
+  fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
+
+  console.log("scenario-stars.json updated!");
+}
+
+main();

--- a/scripts/fetch-stars.js
+++ b/scripts/fetch-stars.js
@@ -29,20 +29,25 @@ async function fetchStars(owner, repo) {
     headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
   }
 
-  const response = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}`,
-    { headers }
-  );
-
-  if (!response.ok) {
-    console.log(
-      `Failed: ${owner}/${repo} - ${response.status} ${response.statusText}`
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}`,
+      { headers }
     );
+
+    if (!response.ok) {
+      console.log(
+        `Failed: ${owner}/${repo} - ${response.status} ${response.statusText}`
+      );
+      return null;
+    }
+
+    const data = await response.json();
+    return data.stargazers_count;
+  } catch (error) {
+    console.error(`Error fetching ${owner}/${repo}:`, error);
     return null;
   }
-
-  const data = await response.json();
-  return data.stargazers_count;
 }
 
 async function main() {
@@ -52,7 +57,18 @@ async function main() {
     );
   }
 
-  const result = {};
+  // Read existing star counts (if any) so failed requests don't erase them.
+  let result = {};
+
+  if (fs.existsSync(outputPath)) {
+    try {
+      result = JSON.parse(fs.readFileSync(outputPath, "utf-8"));
+    } catch (error) {
+      console.warn(
+        "Warning: Could not read existing scenario-stars.json. A new file will be created."
+      );
+    }
+  }
 
   for (const template of templates) {
     if (!template.source) continue;
@@ -63,20 +79,14 @@ async function main() {
 
     const stars = await fetchStars(repoInfo.owner, repoInfo.repo);
 
+    // Only overwrite if the fetch succeeded.
     if (stars !== null) {
       result[template.source] = {
         stars,
       };
 
-      console.log(`${repoInfo.owner}/${repoInfo.repo} : ${stars}`);
+      console.log(`${repoInfo.owner}/${repoInfo.repo}: ${stars}`);
     }
-  }
-
-  if (Object.keys(result).length === 0) {
-    console.log(
-      "No stars fetched. Keeping existing scenario-stars.json unchanged."
-    );
-    return;
   }
 
   fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));

--- a/site/src/pages/gallery.astro
+++ b/site/src/pages/gallery.astro
@@ -17,6 +17,7 @@ import {
   type FilterSection,
 } from "../lib/templates";
 import type { TagType } from "../data/tags-shim";
+import scenarioStars from "../../../static/scenario-stars.json";
 
 const data = allTemplates;
 
@@ -237,7 +238,12 @@ const stripes = [
                   {t.title}
                 </a>
               </h3>
-              <p class="mb-3 text-xs text-neutral-500 dark:text-neutral-400">by {t.author}</p>
+              <p class="mb-3 text-xs text-neutral-500 dark:text-neutral-400">
+                by {t.author}
+                {scenarioStars[t.source]?.stars > 0 && (
+                  <span class="ml-2 text-neutral-600 dark:text-neutral-500">★ {scenarioStars[t.source].stars}</span>
+                )}
+              </p>
 
               <p class="mb-4 line-clamp-3 flex-1 text-sm leading-relaxed text-neutral-700 dark:text-neutral-300">
                 {t.description}

--- a/site/src/pages/gallery.astro
+++ b/site/src/pages/gallery.astro
@@ -239,11 +239,22 @@ const stripes = [
                 </a>
               </h3>
               <p class="mb-3 text-xs text-neutral-500 dark:text-neutral-400">
-                by {t.author}
-                {scenarioStars[t.source]?.stars > 0 && (
-                  <span class="ml-2 text-neutral-600 dark:text-neutral-500">★ {scenarioStars[t.source].stars}</span>
-                )}
-              </p>
+  by {t.author}
+  {t.source && scenarioStars[t.source]?.stars > 0 && (
+    <span class="ml-2 inline-flex items-center gap-1 font-medium text-yellow-500 dark:text-yellow-400">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-4 w-4 fill-current"
+        viewBox="0 0 20 20"
+        aria-hidden="true"
+      >
+        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.176 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81H7.03a1 1 0 00.95-.69l1.07-3.292z" />
+      </svg>
+
+      <span>{scenarioStars[t.source]?.stars}</span>
+    </span>
+  )}
+</p>
 
               <p class="mb-4 line-clamp-3 flex-1 text-sm leading-relaxed text-neutral-700 dark:text-neutral-300">
                 {t.description}

--- a/static/scenario-stars.json
+++ b/static/scenario-stars.json
@@ -1,0 +1,182 @@
+{
+  "https://github.com/petender/ConferenceAPI": {
+    "stars": 2
+  },
+  "https://github.com/petender/azd-apimwithconfAPI": {
+    "stars": 1
+  },
+  "https://github.com/petender/OpenAIMultiModel": {
+    "stars": 1
+  },
+  "https://github.com/rob-foulkrod/TollBooth": {
+    "stars": 3
+  },
+  "https://github.com/rob-foulkrod/BadgeMaker": {
+    "stars": 4
+  },
+  "https://github.com/rob-foulkrod/MachineLearningAZD": {
+    "stars": 4
+  },
+  "https://github.com/rob-foulkrod/IAAS2019": {
+    "stars": 2
+  },
+  "https://github.com/maartenvandiemen/AZD-ACI-Demo": {
+    "stars": 1
+  },
+  "https://github.com/maartenvandiemen/AZD-ACA-Demo": {
+    "stars": 3
+  },
+  "https://github.com/maartenvandiemen/AZD-AKS-Demo": {
+    "stars": 1
+  },
+  "https://github.com/petender/azd-fdcdn": {
+    "stars": 2
+  },
+  "https://github.com/maartenvandiemen/AZD-PaaS-Demo": {
+    "stars": 3
+  },
+  "https://github.com/true-while/event-hub-azd": {
+    "stars": 1
+  },
+  "https://github.com/petender/azd-hubspoke": {
+    "stars": 1
+  },
+  "https://github.com/petender/azd-site2sitevpn/": {
+    "stars": 1
+  },
+  "https://github.com/maartenvandiemen/AZD-WatermarkFunction": {
+    "stars": 2
+  },
+  "https://github.com/petender/azd-sentinel": {
+    "stars": 1
+  },
+  "https://github.com/petender/azd-trafficmgr": {
+    "stars": 0
+  },
+  "https://github.com/rob-foulkrod/purviewEnvironment-azd": {
+    "stars": 2
+  },
+  "https://github.com/sarahallali/azd-Privatelink-Pendpoint": {
+    "stars": 3
+  },
+  "https://github.com/koenraadhaedens/azd-nestedhv-dc-rtr": {
+    "stars": 2
+  },
+  "https://github.com/koenraadhaedens/AZD-WIN11-DEV-PC-DOCKER": {
+    "stars": 1
+  },
+  "https://github.com/koenraadhaedens/azd-infra-dev-containers": {
+    "stars": 6
+  },
+  "https://github.com/rob-foulkrod/tdd-functions-e2e-http-to-eventhubs": {
+    "stars": 2
+  },
+  "https://github.com/true-while/owasp-azd/": {
+    "stars": 0
+  },
+  "https://github.com/maartenvandiemen/azd-loadtest/": {
+    "stars": 1
+  },
+  "https://github.com/true-while/secure-data-solutions/": {
+    "stars": 0
+  },
+  "https://github.com/ronaldbosma/azure-integration-services-quickstart": {
+    "stars": 8
+  },
+  "https://github.com/petender/azd-storaccnt": {
+    "stars": 1
+  },
+  "https://github.com/daverendon/azd-deepseek-r1-on-azure-container-apps": {
+    "stars": 2
+  },
+  "https://github.com/petender/azd-youtubesummarizer-openai": {
+    "stars": 0
+  },
+  "https://github.com/petender/issdata": {
+    "stars": 2
+  },
+  "https://github.com/daverendon/azd-baseline-webapp": {
+    "stars": 1
+  },
+  "https://github.com/daverendon/azd-firewall": {
+    "stars": 1
+  },
+  "https://github.com/vincentk16/azd-vision-face": {
+    "stars": 0
+  },
+  "https://github.com/petender/azd-addsvm": {
+    "stars": 0
+  },
+  "https://github.com/petender/azd-sqlao": {
+    "stars": 0
+  },
+  "https://github.com/trainerkrunal/azd-vmwithlb": {
+    "stars": 0
+  },
+  "https://github.com/daverendon/azd-service-endpoints-and-securing-storage": {
+    "stars": 1
+  },
+  "https://github.com/daverendon/azd-intersite-connectivity": {
+    "stars": 1
+  },
+  "https://github.com/michelmsft/GoodFood/": {
+    "stars": 2
+  },
+  "https://github.com/maartenvandiemen/AZD-AppConfiguration": {
+    "stars": 1
+  },
+  "https://github.com/daverendon/azd-private-link": {
+    "stars": 1
+  },
+  "https://github.com/koenraadhaedens/azd-sqlworloadsim": {
+    "stars": 0
+  },
+  "https://github.com/SQLtattoo/azd-az104-all-in-one": {
+    "stars": 6
+  },
+  "https://github.com/petender/azd-ai-agent-service": {
+    "stars": 1
+  },
+  "https://github.com/petender/azd-foundrysora": {
+    "stars": 0
+  },
+  "https://github.com/kareldewinter/tdd-azd-monitor": {
+    "stars": 3
+  },
+  "https://github.com/rob-foulkrod/azd-apimwithconfAPI-OAuth": {
+    "stars": 0
+  },
+  "https://github.com/daverendon/azd-microsoft-sentinel": {
+    "stars": 2
+  },
+  "https://github.com/true-while/pg-ai-azd": {
+    "stars": 0
+  },
+  "https://github.com/ronaldbosma/protect-apim-with-oauth": {
+    "stars": 0
+  },
+  "https://github.com/ronaldbosma/call-apim-backend-with-oauth": {
+    "stars": 2
+  },
+  "https://github.com/ronaldbosma/call-apim-with-managed-identity": {
+    "stars": 0
+  },
+  "https://github.com/daverendon/azd-hardened-webapp": {
+    "stars": 1
+  },
+  "https://github.com/petender/azd-researcher": {
+    "stars": 2
+  },
+  "https://github.com/daverendon/azd-multiagent": {
+    "stars": 4
+  },
+  "https://github.com/passadis/azure-a2a-translation": {
+    "stars": 0
+  },
+  "https://github.com/koenraadhaedens/azd-firewall-send-syslog-messages": {
+    "stars": 0
+  },
+  "https://github.com/petender/demo-mcp-productcatalog": {
+    "stars": 3
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds GitHub star counts to the Azure Trainer Demo Deploy catalog cards.

## Changes

- Added a script (`scripts/fetch-stars.js`) to fetch GitHub star counts
- Generated a static `scenario-stars.json` file
- Updated the gallery page to display GitHub stars on catalog cards
- Updated `package.json` to support the star generation workflow

## Testing

- Verified the star generation script locally
- Confirmed that star counts are displayed correctly on the gallery page