### PR TITLE
Add Azure VM management MCP server entry to templates

### DIFF
--- a/static/templates.json
+++ b/static/templates.json
@@ -930,5 +930,17 @@
   "demoguide": "https://raw.githubusercontent.com/petender/tdd-azd-linux-vm-ssh-nsg/refs/heads/main/demoguide/demoguide.md",
   "deploytime": "3",
   "cost": "5.00"
+  },
+  {
+    "title": "Azure VM management MCP server for AI Agent",
+    "description": "This is deploying a  MCP server in a ACI for connecting to a Microsoft Copilot Studio agent",
+    "preview": "https://raw.githubusercontent.com/koenraadhaedens/azd-azure-vmtool-mcpserver/main/media/screenschot-agent6.jpg",
+    "website": "https://github.com/koenraadhaedens",
+    "author": "Koenraad Haedens",
+    "source": "https://github.com/koenraadhaedens/azd-azure-vmtool-mcpserver",
+    "tags": ["pl-7008", "ai-3026", "msft", "hot"],
+    "demoguide": "https://raw.githubusercontent.com/koenraadhaedens/azd-azure-vmtool-mcpserver/main/docs/demo-guide.md",
+    "cost": "1",
+    "deploytime": "1",
   }
 ]


### PR DESCRIPTION
This pull request adds a new template entry for an Azure VM management MCP server designed to connect with a Microsoft Copilot Studio agent. The update introduces relevant metadata, links, and tags to the `static/templates.json` file.

**New template addition:**

* Added a new template for "Azure VM management MCP server for AI Agent" with details such as description, preview image, author, source repository, demo guide, tags, cost, and deploy time.