### PR TITLE
Add current ILT course portfolio to catalog

### DIFF
--- a/site/src/data/tags-shim.ts
+++ b/site/src/data/tags-shim.ts
@@ -6,5 +6,5 @@
  * import through this shim so site-side modules use a stable,
  * JSX-free module specifier.
  */
-export { Tags } from "../../../src/data/tags.tsx";
+export { CatalogCourseTags, Tags } from "../../../src/data/tags.tsx";
 export type { Tag, TagType, User } from "../../../src/data/tags.tsx";

--- a/site/src/lib/templates.test.ts
+++ b/site/src/lib/templates.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { CatalogCourseTags } from "../data/tags-shim";
 import type { TagType } from "../data/tags-shim";
 import {
   allTemplates,
@@ -7,6 +8,7 @@ import {
   getAuthorsWithCounts,
   getTagsBySection,
   getUniqueAuthors,
+  tagMeta,
   tagSection,
   templateSlug,
   type Template,
@@ -178,6 +180,78 @@ describe("getTagsBySection", () => {
         expect(seen.has(entry.tag)).toBe(false);
         seen.add(entry.tag);
       }
+    }
+  });
+});
+
+describe("CatalogCourseTags", () => {
+  it("contains the current course portfolio", () => {
+    expect(CatalogCourseTags).toEqual([
+      "ab-100",
+      "ab-6008",
+      "ab-620",
+      "ab-730",
+      "ab-731",
+      "ai-103",
+      "ai-200",
+      "ai-300",
+      "ai-3003",
+      "ai-3008",
+      "ai-3016",
+      "ai-3025",
+      "ai-3026",
+      "ai-901",
+      "az-104",
+      "az-2007",
+      "az-2008",
+      "az-305",
+      "az-400",
+      "az-500",
+      "az-700",
+      "dp-300",
+      "dp-3011",
+      "dp-3014",
+      "dp-3028",
+      "dp-3029",
+      "dp-600",
+      "dp-601",
+      "dp-602",
+      "dp-603",
+      "dp-604",
+      "dp-605",
+      "dp-700",
+      "dp-750",
+      "dp-800",
+      "dp-900",
+      "gh-100",
+      "gh-200",
+      "gh-300",
+      "gh-500",
+      "gh-600",
+      "gh-900",
+      "md-4011",
+      "ms-4002",
+      "ms-4004",
+      "ms-4014",
+      "ms-4017",
+      "ms-4018",
+      "ms-4019",
+      "ms-4021",
+      "ms-4022",
+      "ms-4023",
+      "pl-300",
+      "pl-7008",
+      "sc-100",
+      "sc-200",
+      "sc-300",
+      "sc-401",
+    ]);
+  });
+
+  it("registers every portfolio course as an ILT course", () => {
+    for (const tag of CatalogCourseTags) {
+      expect(tagMeta(tag), `missing course metadata for '${tag}'`).toBeDefined();
+      expect(tagSection(tag), `${tag} is not an ILT course`).toBe("ILT Courses");
     }
   });
 });

--- a/site/src/pages/gallery.astro
+++ b/site/src/pages/gallery.astro
@@ -16,17 +16,19 @@ import {
   FILTER_SECTIONS,
   type FilterSection,
 } from "../lib/templates";
+import { CatalogCourseTags } from "../data/tags-shim";
 import type { TagType } from "../data/tags-shim";
 
 const data = allTemplates;
 
 /**
- * Every tag actually used by the catalog, looked up against the Tags
- * metadata table. We bucket by `tagSection` (which returns null for
- * special sentinel tags like hot/new/mct/msft).
+ * Demo-backed tags plus the current course portfolio. Curated courses
+ * without demos remain visible in the filter rail as disabled options.
  */
 const tagsInUse = new Set<TagType>();
 data.forEach((t) => t.tags?.forEach((tag) => tagsInUse.add(tag)));
+const filterTags = new Set<TagType>(tagsInUse);
+CatalogCourseTags.forEach((tag) => filterTags.add(tag));
 
 function labelFor(id: TagType): string {
   return tagMeta(id)?.label ?? id;
@@ -39,7 +41,7 @@ const groups: Record<GroupKey, TagType[]> = {
   "ILT Courses": [],
   Frameworks: [],
 };
-for (const id of tagsInUse) {
+for (const id of filterTags) {
   const section = tagSection(id);
   groups[section ?? "special"].push(id);
 }
@@ -54,7 +56,7 @@ for (const id of tagsInUse) {
  */
 const tagMetaForClient: Record<string, { label: string; section: FilterSection | null }> =
   Object.fromEntries(
-    [...tagsInUse].map((id) => [id, { label: labelFor(id), section: tagSection(id) }]),
+    [...filterTags].map((id) => [id, { label: labelFor(id), section: tagSection(id) }]),
   );
 
 const authors = [...new Set(data.map((t) => t.author).filter(Boolean))].sort((a, b) =>
@@ -139,8 +141,16 @@ const stripes = [
           </summary>
           <div class="mt-3 max-h-72 space-y-2 overflow-y-auto pr-2">
             {groups[section].map((id) => (
-              <label class="flex cursor-pointer items-start gap-2 text-sm">
-                <input type="checkbox" class="tag-cb mt-0.5 accent-brand-violet" data-tag={id} />
+              <label
+                class={`flex items-start gap-2 text-sm ${tagsInUse.has(id) ? "cursor-pointer" : "cursor-not-allowed opacity-50"}`}
+                title={tagsInUse.has(id) ? undefined : "No demos available yet"}
+              >
+                <input
+                  type="checkbox"
+                  class="tag-cb mt-0.5 accent-brand-violet"
+                  data-tag={id}
+                  disabled={!tagsInUse.has(id)}
+                />
                 <span class="text-neutral-700 dark:text-neutral-300">{labelFor(id)}</span>
               </label>
             ))}

--- a/src/data/tags.tsx
+++ b/src/data/tags.tsx
@@ -39,8 +39,16 @@ export type TagType =
   | "hot"
 
 // ILT Courses
+// Business Applications
+  | "ab-100"
+  | "ab-6008"
+  | "ab-620"
+  | "ab-730"
+  | "ab-731"
+
 // AI
   | "ai-102"
+  | "ai-103"
   | "ai-200"
   | "ai-300"
   | "ai-3002"
@@ -71,6 +79,8 @@ export type TagType =
   | "az-2003"
   | "az-2005"
   | "az-2006"
+  | "az-2007"
+  | "az-2008"
   | "az-204"
   | "az-305"
   | "az-400"
@@ -102,12 +112,37 @@ export type TagType =
   | "dp-604"
   | "dp-605"
   | "dp-700"
+  | "dp-750"
+  | "dp-800"
   | "dp-900"
+
+// GitHub
+  | "gh-100"
+  | "gh-200"
+  | "gh-300"
+  | "gh-500"
+  | "gh-600"
+  | "gh-900"
+
+// Endpoint
+  | "md-4011"
+
+// Microsoft 365
+  | "ms-4002"
+  | "ms-4004"
+  | "ms-4014"
+  | "ms-4017"
+  | "ms-4018"
+  | "ms-4019"
+  | "ms-4021"
+  | "ms-4022"
+  | "ms-4023"
 
 // Security
   | "sc-100"
   | "sc-200"
   | "sc-300"
+  | "sc-401"
   | "sc-500"
   | "sc-5001"
   | "sc-5002"
@@ -117,6 +152,10 @@ export type TagType =
   | "sc-5007"
   | "sc-5008"
   | "sc-900"
+
+// Power Platform
+  | "pl-300"
+  | "pl-7008"
   // end ILT
 
   // Frameworks
@@ -190,6 +229,67 @@ export type TagType =
 
 ;
 
+export const CatalogCourseTags = [
+  "ab-100",
+  "ab-6008",
+  "ab-620",
+  "ab-730",
+  "ab-731",
+  "ai-103",
+  "ai-200",
+  "ai-300",
+  "ai-3003",
+  "ai-3008",
+  "ai-3016",
+  "ai-3025",
+  "ai-3026",
+  "ai-901",
+  "az-104",
+  "az-2007",
+  "az-2008",
+  "az-305",
+  "az-400",
+  "az-500",
+  "az-700",
+  "dp-300",
+  "dp-3011",
+  "dp-3014",
+  "dp-3028",
+  "dp-3029",
+  "dp-600",
+  "dp-601",
+  "dp-602",
+  "dp-603",
+  "dp-604",
+  "dp-605",
+  "dp-700",
+  "dp-750",
+  "dp-800",
+  "dp-900",
+  "gh-100",
+  "gh-200",
+  "gh-300",
+  "gh-500",
+  "gh-600",
+  "gh-900",
+  "md-4011",
+  "ms-4002",
+  "ms-4004",
+  "ms-4014",
+  "ms-4017",
+  "ms-4018",
+  "ms-4019",
+  "ms-4021",
+  "ms-4022",
+  "ms-4023",
+  "pl-300",
+  "pl-7008",
+  "sc-100",
+  "sc-200",
+  "sc-300",
+  "sc-401",
+] as const satisfies readonly TagType[];
+
 // LIST OF AVAILABLE TAGS
 // Each tag in lit about must have a defined object here
 // One or more tags can be associated per card
@@ -223,6 +323,42 @@ export const Tags: { [type in TagType]: Tag } = {
  
 
   // ---- ILT Courses
+
+  "ab-100": {
+    label: "AB-100 Architecting agentic AI business solutions",
+    description: "Plan, design, and govern agentic AI business solutions built on Microsoft platforms.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ab-100t00",
+  },
+  "ab-6008": {
+    label: "AB-6008 Delegate work with AI",
+    description: "Use Copilot Cowork and Scout to delegate larger work outcomes and automate repeatable workflows.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ab-6008",
+  },
+  "ab-620": {
+    label: "AB-620 Design and build integrated AI agent solutions in Copilot Studio",
+    description: "Design, extend, and integrate production-ready Copilot Studio agents and multi-agent solutions.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ab-620t00",
+  },
+  "ab-730": {
+    label: "AB-730 Transform business workflows with generative AI",
+    description: "Apply generative AI and Microsoft 365 Copilot to streamline workflows and improve business outcomes.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ab-730t00",
+  },
+  "ab-731": {
+    label: "AB-731 Drive AI transformation in your organization",
+    description: "Lead organizational AI transformation by identifying opportunities, aligning investments, and applying responsible AI practices.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ab-731t00",
+  },
   
   "ai-102": {
     label: "AI-102 Azure AI Engineer Associate",
@@ -232,6 +368,13 @@ export const Tags: { [type in TagType]: Tag } = {
     url: "https://learn.microsoft.com/credentials/certifications/azure-ai-engineer/?practice-assessment-type=certification",
     courseblueprint: "",
     courseblueprintdiag: "",
+  },
+  "ai-103": {
+    label: "AI-103 Develop AI apps and agents on Azure",
+    description: "Build generative AI apps and agents with Microsoft Foundry, including multimodal solutions, knowledge connections, and tools.",
+    type: "ILT Courses",
+    azureIcon: "./img/microsoft-certified-associate-badge.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ai-103t00",
   },
   "ai-200": {
     label: "AI-200 Develop AI cloud solutions on Microsoft Azure",
@@ -488,6 +631,19 @@ export const Tags: { [type in TagType]: Tag } = {
     url: "https://learn.microsoft.com/en-us/training/paths/automate-azure-load-testing-github/",
     courseblueprint: "",
     courseblueprintdiag: "",
+  },
+  "az-2007": {
+    label: "AZ-2007 Get started with AI-assisted development",
+    description: "Use AI-assisted development tools to improve software development workflows.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+  },
+  "az-2008": {
+    label: "AZ-2008 DevOps Foundations: The Core Principles and Practices",
+    description: "Learn fundamental DevOps culture and practices across planning, source control, delivery, observability, security, and platform engineering.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/az-2008",
   },
   "az-204": {
     label: "AZ-204 Azure Developer Associate",
@@ -753,6 +909,20 @@ export const Tags: { [type in TagType]: Tag } = {
     courseblueprint: "",
     courseblueprintdiag: ""
   },
+  "dp-750": {
+    label: "DP-750 Implement data engineering solutions using Azure Databricks",
+    description: "Build, secure, deploy, and maintain scalable lakehouse and data pipeline solutions with Azure Databricks and Unity Catalog.",
+    type: "ILT Courses",
+    azureIcon: "./img/microsoft-certified-associate-badge.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/dp-750t00",
+  },
+  "dp-800": {
+    label: "DP-800 Develop AI-enabled database solutions",
+    description: "Design and develop AI-enabled database solutions across SQL Server, Azure SQL, and SQL databases in Microsoft Fabric.",
+    type: "ILT Courses",
+    azureIcon: "./img/microsoft-certified-associate-badge.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/dp-800t00",
+  },
   "dp-900": {
     label: "DP-900 Azure Data Fundamentals",
     description: "Demonstrate foundational knowledge of core data concepts related to Microsoft Azure data services.",
@@ -761,6 +931,118 @@ export const Tags: { [type in TagType]: Tag } = {
     url: "https://learn.microsoft.com/credentials/certifications/azure-data-fundamentals/?practice-assessment-type=certification",
     courseblueprint: "",
     courseblueprintdiag: "",
+  },
+  "gh-100": {
+    label: "GH-100 GitHub fundamentals - Administration basics and product features",
+    description: "Learn GitHub administration basics, repository management, collaboration, and secure repository practices.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/gh-100t00",
+  },
+  "gh-200": {
+    label: "GH-200 Automate your workflow with GitHub Actions",
+    description: "Automate software development workflows, application builds, and GitHub API interactions with GitHub Actions.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/gh-200t00",
+  },
+  "gh-300": {
+    label: "GH-300 GitHub Copilot",
+    description: "Use GitHub Copilot effectively while understanding responsible AI practices and operational risks.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/gh-300t00",
+  },
+  "gh-500": {
+    label: "GH-500 GitHub Advanced Security",
+    description: "Use GitHub Advanced Security to identify and address vulnerabilities throughout the software development lifecycle.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/gh-500t00",
+  },
+  "gh-600": {
+    label: "GH-600 Developing in Agentic AI Systems",
+    description: "Develop, deploy, operate, and govern agentic AI systems in GitHub-based software development workflows.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/gh-600t00",
+  },
+  "gh-900": {
+    label: "GH-900 GitHub Foundations",
+    description: "Learn GitHub fundamentals, including repositories, commits, branches, merging, and collaboration workflows.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/gh-900t00",
+  },
+  "md-4011": {
+    label: "MD-4011 Enhance endpoint security with Microsoft Intune and Microsoft Security Copilot",
+    description: "Use Microsoft Intune and Microsoft Security Copilot to improve device management and endpoint security operations.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/md-4011",
+  },
+  "ms-4002": {
+    label: "MS-4002 Prepare security and compliance to support Microsoft 365 Copilot",
+    description: "Prepare Microsoft 365 security and compliance capabilities for a successful Microsoft 365 Copilot implementation.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ms-4002",
+  },
+  "ms-4004": {
+    label: "MS-4004 Empower your workforce with Microsoft 365 Copilot Use Cases",
+    description: "Apply Microsoft 365 Copilot across common business roles and use cases through hands-on exercises.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ms-4004",
+  },
+  "ms-4014": {
+    label: "MS-4014 Introduction to building AI agents",
+    description: "Explore AI agent concepts, Microsoft's agent platform, and how to plan an end-to-end agent solution.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ms-4014",
+  },
+  "ms-4017": {
+    label: "MS-4017 Manage and extend Microsoft 365 Copilot",
+    description: "Implement, administer, and extend Microsoft 365 Copilot to meet organizational needs.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ms-4017",
+  },
+  "ms-4018": {
+    label: "MS-4018 Draft, analyze, and present with Microsoft 365 Copilot",
+    description: "Use Microsoft 365 Copilot and agents to draft content, analyze data, prepare presentations, and manage communications.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ms-4018",
+  },
+  "ms-4019": {
+    label: "MS-4019 Transform your everyday business processes with agents",
+    description: "Use prebuilt agents and create agents in Microsoft 365 Copilot Chat and SharePoint to improve everyday workflows.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ms-4019",
+  },
+  "ms-4021": {
+    label: "MS-4021 Copilot Immersion Experience",
+    description: "Use contextual prompting and role-based exercises to apply Microsoft 365 Copilot across business functions.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ms-4021",
+  },
+  "ms-4022": {
+    label: "MS-4022 Extend Microsoft 365 Copilot in Copilot Studio",
+    description: "Build and publish Copilot Studio agents with custom knowledge, instructions, tools, and connectors.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ms-4022",
+  },
+  "ms-4023": {
+    label: "MS-4023 Transform Ideas into Action with Copilot Chat (Basic)",
+    description: "Get started with Microsoft 365 Copilot Chat, effective prompting, and secure AI-assisted collaboration.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/ms-4023",
   },
   "sc-100":{
     label: "SC-100 Cybersecurity Architect Expert",
@@ -788,6 +1070,13 @@ export const Tags: { [type in TagType]: Tag } = {
     url: "https://learn.microsoft.com/credentials/certifications/identity-and-access-administrator/?practice-assessment-type=certification",
     courseblueprint: "https://aka.ms/SC-300Blueprint",
     courseblueprintdiag: "https://courseblueprints.blob.core.windows.net/blueprints/SC-300_Blueprint.pdf?sp=r&st=2024-10-10T16:20:37Z&se=2025-07-02T00:20:37Z&spr=https&sv=2022-11-02&sr=b&sig=Q8NZNEY0oa96Olaeyuu8Wf1DeTJ77TJbUmesb6uSjZw%3D",
+  },
+  "sc-401": {
+    label: "SC-401 Protect sensitive information with Microsoft Purview in the AI era",
+    description: "Plan and implement information protection, data loss prevention, retention, insider risk management, and controls for AI data.",
+    type: "ILT Courses",
+    azureIcon: "./img/microsoft-certified-associate-badge.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/sc-401t00",
   },
   "sc-500": {
     label: "SC-500 Implement end-to-end security controls for cloud and AI workloads",
@@ -867,6 +1156,23 @@ export const Tags: { [type in TagType]: Tag } = {
     type: "ILT Courses",
     azureIcon: "./img/microsoft-certified-fundamentals-badge.svg",
     url: "https://learn.microsoft.com/credentials/certifications/security-compliance-and-identity-fundamentals/?practice-assessment-type=certification",
+    courseblueprint: "",
+    courseblueprintdiag: "",
+  },
+
+  "pl-300": {
+    label: "PL-300 Design and manage analytics solutions using Power BI",
+    description: "Model, visualize, analyze, manage, and deploy data solutions with Microsoft Power BI.",
+    type: "ILT Courses",
+    azureIcon: "./img/microsoft-certified-associate-badge.svg",
+    url: "https://learn.microsoft.com/en-us/training/courses/pl-300t00",
+  },
+  "pl-7008": {
+    label: "PL-7008 Create agents in Microsoft Copilot Studio",
+    description: "Create and extend custom agents by using Microsoft Copilot Studio.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/paths/create-extend-custom-copilots-microsoft-copilot-studio/",
     courseblueprint: "",
     courseblueprintdiag: "",
   },


### PR DESCRIPTION
## Summary
- define the canonical 58-course catalog portfolio and add metadata for missing AB, AI, AZ, DP, GH, MD, MS, PL, and SC courses
- add the verified `AI-103 Develop AI apps and agents on Azure` title and Microsoft Learn URL
- show curated courses in the Astro v2 ILT filter even when no demo is tagged, with zero-demo courses displayed as disabled options
- retain existing demo-backed course filters so current scenarios remain discoverable
- add regression coverage for the exact course portfolio and ILT classification

## Validation
- `cd site && npm test` — 48 tests passed across 2 files
- `cd site && npm run check` — 0 errors, 0 warnings, 6 existing hints
- `cd site && npm run build` — 7 pages built successfully
- Playwright against the isolated production build:
  - all 58 required course codes rendered under ILT Courses
  - AI-103 rendered with the verified title and disabled zero-demo state
  - AZ-104 returned 27 valid demos
  - AZ-204 returned 25 valid demos
  - catalog reset to all 81 demos after filtering

