### PR TITLE
Add industry filtering to catalog

### DIFF
--- a/.github/instructions/templates-json.instructions.md
+++ b/.github/instructions/templates-json.instructions.md
@@ -23,6 +23,7 @@ Fields and types:
 - source (string, required) — GitHub repo URL
 - demoguide (string, optional) — raw markdown URL
 - tags (string[], required) — each value must be in TagType
+- industry (string, optional) — business vertical; omit for general-purpose templates
 - cost (string, required) — decimal as string (e.g., "3.00")
 - deploytime (string, required) — minutes as string (e.g., "5")
 - prereqs (string, optional) — raw markdown URL
@@ -30,6 +31,7 @@ Fields and types:
 Conventions:
 - Keep keys in the order listed above
 - All fields are JSON strings except `tags` (array of strings)
+- Missing `industry` values are normalized to `General` by the catalog
 - Deduplicate and sort `tags` lexicographically for stable diffs
 - No trailing commas; entire file must be a single valid JSON array
 
@@ -49,6 +51,7 @@ When a user provides a GitHub repository URL, populate fields as follows:
    - demoguide: README raw URL if it serves as the demo guide, or search for demoguide/*.md, docs/*guide*.md; use raw URL
    - prereqs: search for prereqs.md or similar; use raw URL if present
    - preview: look for images referenced in README (png/svg/jpg/webp). Prefer a repo `static/templates/images/` asset if already in our repo, else the first readable image in the repo via raw URL. If none, set `./templates/images/test.png`.
+   - industry: use a business vertical explicitly named in the README; otherwise omit it so the entry defaults to `General`
 
 2. Infer tags (best-effort, then human-confirm)
    - Map keywords in README and repo topics to TagType values (e.g., aks → "aks", functions → "functions", apim → "apim", dotnet → "dotnet")
@@ -109,6 +112,7 @@ When a user provides a GitHub repository URL, populate fields as follows:
         "items": {"type": "string"},
         "uniqueItems": true
       },
+         "industry": {"type": "string", "minLength": 1},
       "cost": {"type": "string", "pattern": "^\\d+(\\.\\d{1,2})?$"},
       "deploytime": {"type": "string", "pattern": "^\\d+$"},
       "prereqs": {"type": "string", "format": "uri", "pattern": "^https://"}
@@ -122,6 +126,7 @@ When a user provides a GitHub repository URL, populate fields as follows:
 - [ ] JSON parses; array only, no stray objects or trailing commas
 - [ ] Required fields present and non-empty
 - [ ] Tags are valid TagType, unique, sorted, Include at least 1 ILT course from tags
+- [ ] Industry is non-empty when present; omitted entries are treated as `General`
 - [ ] cost and deploytime are strings and match patterns
 - [ ] preview is repo image or local asset path
 - [ ] demoguide/prereqs raw URLs when present

--- a/site/src/data/tags-shim.ts
+++ b/site/src/data/tags-shim.ts
@@ -6,5 +6,5 @@
  * import through this shim so site-side modules use a stable,
  * JSX-free module specifier.
  */
-export { Tags } from "../../../src/data/tags.tsx";
+export { CatalogCourseTags, Tags } from "../../../src/data/tags.tsx";
 export type { Tag, TagType, User } from "../../../src/data/tags.tsx";

--- a/site/src/lib/templates.test.ts
+++ b/site/src/lib/templates.test.ts
@@ -4,9 +4,13 @@ import {
   allTemplates,
   azdInitCommand,
   filterTemplates,
+  GENERAL_INDUSTRY,
   getAuthorsWithCounts,
+  getUniqueIndustries,
   getTagsBySection,
   getUniqueAuthors,
+  normalizeIndustry,
+  tagMeta,
   tagSection,
   templateSlug,
   type Template,
@@ -21,9 +25,22 @@ const sample = (over: Partial<Template> = {}): Template => ({
   source: "https://github.com/petender/tdd-azd-starter",
   demoguide: null,
   tags: ["functions"],
+  industry: GENERAL_INDUSTRY,
   cost: "$",
   deploytime: "5 min",
   ...over,
+});
+
+describe("normalizeIndustry", () => {
+  it("treats missing and blank industry values as General", () => {
+    expect(normalizeIndustry()).toBe(GENERAL_INDUSTRY);
+    expect(normalizeIndustry(null)).toBe(GENERAL_INDUSTRY);
+    expect(normalizeIndustry("   ")).toBe(GENERAL_INDUSTRY);
+  });
+
+  it("trims an explicitly assigned industry", () => {
+    expect(normalizeIndustry("  Healthcare ")).toBe("Healthcare");
+  });
 });
 
 describe("templateSlug", () => {
@@ -64,8 +81,8 @@ describe("azdInitCommand", () => {
 describe("filterTemplates", () => {
   const data: Template[] = [
     sample({ title: "Azure Function Hub", description: "serverless", tags: ["openai"], author: "Alice" }),
-    sample({ title: "Static Web App", description: "frontend hosting", tags: ["functions"], author: "Bob, Carol" }),
-    sample({ title: "Kubernetes Cluster", description: "container orchestration", tags: ["aks"], author: "Dan" }),
+    sample({ title: "Static Web App", description: "frontend hosting", tags: ["functions"], author: "Bob, Carol", industry: "Retail" }),
+    sample({ title: "Kubernetes Cluster", description: "container orchestration", tags: ["aks"], author: "Dan", industry: "Healthcare" }),
   ];
 
   it("returns all when filter is empty", () => {
@@ -96,6 +113,13 @@ describe("filterTemplates", () => {
     expect(filterTemplates(data, { authors: ["Carol"] }).map((t) => t.title)).toEqual([
       "Static Web App",
     ]);
+  });
+
+  it("filters by industries using OR-within-list semantics", () => {
+    const out = filterTemplates(data, { industries: ["Retail", "Healthcare"] }).map(
+      (t) => t.title,
+    );
+    expect(out).toEqual(["Static Web App", "Kubernetes Cluster"]);
   });
 
   it("combines filters with AND semantics", () => {
@@ -139,6 +163,19 @@ describe("getUniqueAuthors", () => {
   it("ignores empty author strings", () => {
     const data = [sample({ author: "" }), sample({ author: "Z" })];
     expect(getUniqueAuthors(data)).toEqual(["Z"]);
+  });
+});
+
+describe("getUniqueIndustries", () => {
+  it("returns unique industries with General first and the rest alphabetized", () => {
+    const data = [
+      sample({ industry: "Retail" }),
+      sample({ industry: GENERAL_INDUSTRY }),
+      sample({ industry: "Healthcare" }),
+      sample({ industry: "Retail" }),
+    ];
+
+    expect(getUniqueIndustries(data)).toEqual([GENERAL_INDUSTRY, "Healthcare", "Retail"]);
   });
 });
 
@@ -191,5 +228,18 @@ describe("real catalog data integrity (smoke test)", () => {
     const titles = allTemplates.map((t) => t.title.toLowerCase());
     const sorted = [...titles].sort((a, b) => a.localeCompare(b));
     expect(titles).toEqual(sorted);
+  });
+
+  it("registers every catalog tag and leaves only badges unsectioned", () => {
+    const badgeTags = new Set<TagType>(["hot", "new", "mct", "msft"]);
+
+    for (const template of allTemplates) {
+      for (const tag of template.tags) {
+        expect(tagMeta(tag), `${template.title}: unknown tag '${tag}'`).toBeDefined();
+        if (!badgeTags.has(tag)) {
+          expect(tagSection(tag), `${template.title}: unsectioned tag '${tag}'`).not.toBeNull();
+        }
+      }
+    }
   });
 });

--- a/site/src/lib/templates.ts
+++ b/site/src/lib/templates.ts
@@ -6,6 +6,8 @@ import templatesJson from "../../../static/templates.json";
 import { Tags } from "../data/tags-shim";
 import type { Tag, TagType } from "../data/tags-shim";
 
+export const GENERAL_INDUSTRY = "General";
+
 export type Template = {
   title: string;
   description: string;
@@ -16,10 +18,22 @@ export type Template = {
   demoguide: string | null;
   courseblueprint?: string | null;
   tags: TagType[];
+  industry: string;
   cost: string;
   deploytime: string;
   prereqs?: string;
 };
+
+type TemplateJson = Omit<Template, "industry"> & {
+  industry?: string | null;
+};
+
+export function normalizeIndustry(industry?: string | null): string {
+  const normalized = industry?.trim();
+  return normalized?.toLowerCase() === GENERAL_INDUSTRY.toLowerCase() || !normalized
+    ? GENERAL_INDUSTRY
+    : normalized;
+}
 
 /** Stable slug for deep-link `?id=<slug>` URLs. */
 export function templateSlug(t: Pick<Template, "title">): string {
@@ -30,7 +44,10 @@ export function templateSlug(t: Pick<Template, "title">): string {
     .replace(/^-+|-+$/g, "");
 }
 
-const all = (templatesJson as Template[]).map((t) => ({ ...t }));
+const all = (templatesJson as TemplateJson[]).map((t) => ({
+  ...t,
+  industry: normalizeIndustry(t.industry),
+}));
 all.sort((a, b) => a.title.toLowerCase().localeCompare(b.title.toLowerCase()));
 
 /** All templates, sorted alphabetically by title (case-insensitive). */
@@ -49,6 +66,15 @@ export function getUniqueAuthors(templates: Template[] = allTemplates): string[]
   return Array.from(set).sort((a, b) => a.localeCompare(b));
 }
 
+export function getUniqueIndustries(templates: Template[] = allTemplates): string[] {
+  const industries = new Set(templates.map((template) => normalizeIndustry(template.industry)));
+  return Array.from(industries).sort((left, right) => {
+    if (left === GENERAL_INDUSTRY) return -1;
+    if (right === GENERAL_INDUSTRY) return 1;
+    return left.localeCompare(right);
+  });
+}
+
 /** Unique tags actually used by the catalog (for the filter rail). */
 export function getUsedTags(templates: Template[] = allTemplates): TagType[] {
   const set = new Set<TagType>();
@@ -65,6 +91,8 @@ export type CatalogFilter = {
   tags?: TagType[];
   /** Authors — OR within the list. */
   authors?: string[];
+  /** Industries — OR within the list. */
+  industries?: string[];
 };
 
 /** Apply filters. Empty/undefined fields are pass-through. */
@@ -75,6 +103,10 @@ export function filterTemplates(
   const search = filter.search?.trim().toLowerCase();
   const tags = filter.tags && filter.tags.length > 0 ? new Set(filter.tags) : null;
   const authors = filter.authors && filter.authors.length > 0 ? new Set(filter.authors) : null;
+  const industries =
+    filter.industries && filter.industries.length > 0
+      ? new Set(filter.industries.map(normalizeIndustry))
+      : null;
 
   return templates.filter((t) => {
     if (search) {
@@ -89,6 +121,7 @@ export function filterTemplates(
       const ta = t.author.split(",").map((a) => a.trim());
       if (!ta.some((x) => authors.has(x))) return false;
     }
+    if (industries && !industries.has(normalizeIndustry(t.industry))) return false;
     return true;
   });
 }

--- a/site/src/pages/contribute.astro
+++ b/site/src/pages/contribute.astro
@@ -170,10 +170,16 @@ const steps = [
   "authorLink":  "https://github.com/yourusername",
   "repo":        "https://github.com/yourusername/tdd-your-scenario",
   "tags":        ["AZ-104", "storage", "networking"],
+  "industry":    "Healthcare",
   "demoGuide":   "https://github.com/yourusername/tdd-your-scenario/blob/main/demoguide/demoguide.md",
   "deployTime":  "15 minutes",
   "cost":        "$8-12/day"
 }`}</code></pre>
+
+    <p class="mt-3 text-sm text-neutral-600 dark:text-neutral-300">
+      The <code class="px-1 rounded bg-neutral-100 dark:bg-neutral-800 text-[0.9em]">industry</code> field is optional.
+      Omit it for a general-purpose template; the catalog will classify that entry as <strong>General</strong>.
+    </p>
 
     <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
       <div class="rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5">

--- a/site/src/pages/gallery.astro
+++ b/site/src/pages/gallery.astro
@@ -11,6 +11,7 @@ import Base from "../layouts/Base.astro";
 import {
   allTemplates,
   azdInitCommand,
+  getUniqueIndustries,
   tagMeta,
   tagSection,
   FILTER_SECTIONS,
@@ -60,6 +61,7 @@ const tagMetaForClient: Record<string, { label: string; section: FilterSection |
 const authors = [...new Set(data.map((t) => t.author).filter(Boolean))].sort((a, b) =>
   a.localeCompare(b),
 );
+const industries = getUniqueIndustries(data);
 
 const stripes = [
   "from-brand-violet to-brand-magenta",
@@ -130,22 +132,43 @@ const stripes = [
       </div>
 
       {FILTER_SECTIONS.map((section) => (
-        <details class="group border-t border-neutral-200 pt-4 dark:border-neutral-800">
-          <summary class="flex cursor-pointer list-none items-center justify-between text-sm font-medium">
-            <span>{section}</span>
-            <svg class="h-4 w-4 transition-transform group-open:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="6 9 12 15 18 9" />
-            </svg>
-          </summary>
-          <div class="mt-3 max-h-72 space-y-2 overflow-y-auto pr-2">
-            {groups[section].map((id) => (
-              <label class="flex cursor-pointer items-start gap-2 text-sm">
-                <input type="checkbox" class="tag-cb mt-0.5 accent-brand-violet" data-tag={id} />
-                <span class="text-neutral-700 dark:text-neutral-300">{labelFor(id)}</span>
-              </label>
-            ))}
-          </div>
-        </details>
+        <>
+          <details class="group border-t border-neutral-200 pt-4 dark:border-neutral-800">
+            <summary class="flex cursor-pointer list-none items-center justify-between text-sm font-medium">
+              <span>{section}</span>
+              <svg class="h-4 w-4 transition-transform group-open:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </summary>
+            <div class="mt-3 max-h-72 space-y-2 overflow-y-auto pr-2">
+              {groups[section].map((id) => (
+                <label class="flex cursor-pointer items-start gap-2 text-sm">
+                  <input type="checkbox" class="tag-cb mt-0.5 accent-brand-violet" data-tag={id} />
+                  <span class="text-neutral-700 dark:text-neutral-300">{labelFor(id)}</span>
+                </label>
+              ))}
+            </div>
+          </details>
+
+          {section === "ILT Courses" && (
+            <details open class="group border-t border-neutral-200 pt-4 dark:border-neutral-800">
+              <summary class="flex cursor-pointer list-none items-center justify-between text-sm font-medium">
+                <span>Industry</span>
+                <svg class="h-4 w-4 transition-transform group-open:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </summary>
+              <div class="mt-3 max-h-72 space-y-2 overflow-y-auto pr-2">
+                {industries.map((industry) => (
+                  <label class="flex cursor-pointer items-start gap-2 text-sm">
+                    <input type="checkbox" class="industry-cb mt-0.5 accent-brand-violet" data-industry={industry} />
+                    <span class="text-neutral-700 dark:text-neutral-300">{industry}</span>
+                  </label>
+                ))}
+              </div>
+            </details>
+          )}
+        </>
       ))}
 
       <details class="group border-t border-neutral-200 pt-4 dark:border-neutral-800">
@@ -200,6 +223,7 @@ const stripes = [
               class="card group relative flex cursor-pointer flex-col overflow-hidden rounded-xl border border-neutral-200 bg-white p-5 transition-all duration-200 hover:-translate-y-1 hover:border-brand-violet/40 hover:shadow-xl hover:shadow-brand-violet/20 dark:border-neutral-800 dark:bg-neutral-900"
               data-tags={(t.tags ?? []).join(",")}
               data-author={t.author}
+              data-industry={t.industry}
               data-title={t.title}
               data-haystack={haystack}
               data-index={i}
@@ -284,6 +308,7 @@ const stripes = [
       const sort = document.getElementById('sort');
       const tagCbs = document.querySelectorAll('.tag-cb');
       const authorCbs = document.querySelectorAll('.author-cb');
+      const industryCbs = document.querySelectorAll('.industry-cb');
       const cards = Array.from(grid.querySelectorAll('.card'));
 
       // Shareable URL: mirrors the original site's query params so links
@@ -292,6 +317,7 @@ const stripes = [
       const SEARCH_PARAM = 'name';
       const TAGS_PARAM = 'tags';
       const AUTHORS_PARAM = 'authors';
+      const INDUSTRIES_PARAM = 'industries';
 
       function syncUrl() {
         const params = new URLSearchParams(window.location.search);
@@ -309,6 +335,11 @@ const stripes = [
           .filter((c) => c.checked)
           .forEach((c) => params.append(AUTHORS_PARAM, c.dataset.author));
 
+        params.delete(INDUSTRIES_PARAM);
+        Array.from(industryCbs)
+          .filter((c) => c.checked)
+          .forEach((c) => params.append(INDUSTRIES_PARAM, c.dataset.industry));
+
         const qs = params.toString();
         const next = window.location.pathname + (qs ? '?' + qs : '') + window.location.hash;
         window.history.replaceState(null, '', next);
@@ -318,16 +349,19 @@ const stripes = [
         const term = (q.value || '').trim().toLowerCase();
         const selectedTags = Array.from(tagCbs).filter((c) => c.checked).map((c) => c.dataset.tag);
         const selectedAuthors = Array.from(authorCbs).filter((c) => c.checked).map((c) => c.dataset.author);
+        const selectedIndustries = Array.from(industryCbs).filter((c) => c.checked).map((c) => c.dataset.industry);
 
         let shown = 0;
         cards.forEach((card) => {
           const tags = (card.dataset.tags || '').split(',');
           const author = card.dataset.author || '';
+          const industry = card.dataset.industry || '';
           const hay = card.dataset.haystack || '';
           const matchesTerm = !term || hay.includes(term);
           const matchesTags = selectedTags.length === 0 || selectedTags.every((t) => tags.includes(t));
           const matchesAuthors = selectedAuthors.length === 0 || selectedAuthors.includes(author);
-          const show = matchesTerm && matchesTags && matchesAuthors;
+          const matchesIndustries = selectedIndustries.length === 0 || selectedIndustries.includes(industry);
+          const show = matchesTerm && matchesTags && matchesAuthors && matchesIndustries;
           card.style.display = show ? '' : 'none';
           if (show) shown++;
         });
@@ -362,12 +396,19 @@ const stripes = [
           apply();
         }),
       );
+      industryCbs.forEach((cb) =>
+        cb.addEventListener('change', () => {
+          syncUrl();
+          apply();
+        }),
+      );
       sort?.addEventListener('change', applySort);
 
       document.getElementById('clear-filters')?.addEventListener('click', () => {
         q.value = '';
         tagCbs.forEach((cb) => (cb.checked = false));
         authorCbs.forEach((cb) => (cb.checked = false));
+        industryCbs.forEach((cb) => (cb.checked = false));
         syncUrl();
         apply();
       });
@@ -411,6 +452,13 @@ const stripes = [
       if (initialAuthors.size) {
         authorCbs.forEach((cb) => {
           if (initialAuthors.has(cb.dataset.author)) cb.checked = true;
+        });
+      }
+
+      const initialIndustries = new Set(initialParams.getAll(INDUSTRIES_PARAM));
+      if (initialIndustries.size) {
+        industryCbs.forEach((cb) => {
+          if (initialIndustries.has(cb.dataset.industry)) cb.checked = true;
         });
       }
 

--- a/src/data/tags.tsx
+++ b/src/data/tags.tsx
@@ -24,6 +24,7 @@ export type User = {
   demoguide: string | null;
   courseblueprint: string | null;
   tags: TagType[];
+  industry?: string;
   cost: string;
   deploytime: string;
   prereqs: string;
@@ -117,6 +118,9 @@ export type TagType =
   | "sc-5007"
   | "sc-5008"
   | "sc-900"
+
+// Power Platform
+  | "pl-7008"
   // end ILT
 
   // Frameworks
@@ -133,6 +137,9 @@ export type TagType =
   | "cosmosdb"
   | "azuredatafactory"
   | "monitor"
+  | "networkwatcher"
+  | "virtualnetworkmanager"
+  | "webapplicationfirewall"
   | "keyvault"
   | "aca"
   | "aci"
@@ -871,6 +878,16 @@ export const Tags: { [type in TagType]: Tag } = {
     courseblueprintdiag: "",
   },
 
+  "pl-7008": {
+    label: "PL-7008 Create agents in Microsoft Copilot Studio",
+    description: "Create and extend custom agents by using Microsoft Copilot Studio.",
+    type: "ILT Courses",
+    azureIcon: "./img/applied-skill.svg",
+    url: "https://learn.microsoft.com/en-us/training/paths/create-extend-custom-copilots-microsoft-copilot-studio/",
+    courseblueprint: "",
+    courseblueprintdiag: "",
+  },
+
   // ---- Database
   mongodb: {
     label: "MongoDB",
@@ -954,6 +971,24 @@ export const Tags: { [type in TagType]: Tag } = {
     description: "Template architecture uses Azure Monitor Service",
     azureIcon: "./img/Azure-Monitor.svg",
     url: "https://azure.microsoft.com/products/monitor",
+    type: "Service",
+  },
+  networkwatcher: {
+    label: "Azure Network Watcher",
+    description: "Template architecture uses Azure Network Watcher",
+    url: "https://learn.microsoft.com/azure/network-watcher/network-watcher-monitoring-overview",
+    type: "Service",
+  },
+  virtualnetworkmanager: {
+    label: "Azure Virtual Network Manager",
+    description: "Template architecture uses Azure Virtual Network Manager",
+    url: "https://learn.microsoft.com/azure/virtual-network-manager/overview",
+    type: "Service",
+  },
+  webapplicationfirewall: {
+    label: "Azure Web Application Firewall",
+    description: "Template architecture uses Azure Web Application Firewall",
+    url: "https://learn.microsoft.com/azure/web-application-firewall/overview",
     type: "Service",
   },
   keyvault: {

--- a/static/templates.json
+++ b/static/templates.json
@@ -903,7 +903,7 @@
   "author": "Vassilis Ioannidis",
   "source": "https://github.com/SQLtattoo/az700env",
   "demoguide": "https://raw.githubusercontent.com/SQLtattoo/az700env/refs/heads/main/demoguide/demoguide.md",
-  "tags": ["az-700", "msft", "appgateway", "loadbalancer", "vnets", "privatelink", "firewall", "vpn", "avnm", "afd", "waf", "atm", "flow-logs", "monitoring", "hot"],
+  "tags": ["appgateway", "az-700", "azurefirewall", "frontdoor", "hot", "loadbalancer", "monitor", "msft", "networkwatcher", "privatelink", "trafficmgr", "virtualnetworkmanager", "vnets", "vpngw", "webapplicationfirewall"],
   "cost": "25.00",
   "deploytime": "25"
   },


### PR DESCRIPTION
## Scenario Overview

This is a catalog UX and metadata-contract change, not a new demo scenario. It adds an optional `industry` field, treats existing entries as `General`, and adds URL-synchronized industry filtering to the Astro gallery.

**Project folder**: N/A
**Industry**: Existing templates default to `General`; future entries can declare a business vertical.

## Architecture

No Azure infrastructure changes are included.

| Service | SKU | Purpose |
| ------- | --- | ------- |
| Catalog site | N/A | Filter templates by industry and canonical Azure service tags |

## Artifact Checklist (included in PR)

### Required

- [x] Normalize missing or blank industry metadata to `General`
- [x] Add the Industry filter immediately after ILT Courses
- [x] Preserve `hot`, `MCT Authored`, `MTT Authored`, and `New` as the only unsectioned badges
- [x] Map stray AZ-700 networking tags to canonical Azure Services
- [x] Document the optional `industry` catalog field
- [x] Add regression coverage for industry filtering and catalog tag registration

> **Note:** The scenario artifact checklist is not applicable because this PR changes the catalog site and metadata schema only.

## Deployment Status

- [x] **Not deployed** — Static site changes were validated locally.

## Sensitive Data Confirmation

- [x] No `.azure/` deployment state files included
- [x] No `.env` or secret files included
- [x] No `bin/`, `obj/`, or `publish/` build outputs included
- [x] No `applogs/` or `*.zip` archives included

## Reviewer Guidance

1. Run `npm --prefix site test` — 53 tests pass.
2. Run `npm --prefix site run check` — 0 errors and 0 warnings (6 existing Astro hints).
3. Run `npm --prefix site run build` — all 7 routes build successfully.
4. Verify the sidebar order is Azure Services, ILT Courses, Industry, Frameworks, Authors.
5. Verify existing entries appear under `General` and shareable URLs use `?industries=General`.
6. Verify all catalog tags are registered and only the four intentional badges remain unsectioned.

The branch includes the latest `origin/main` via merge commit before this PR was opened.