### PR TITLE
Add catalog industry metadata

### DIFF
--- a/static/templates.json
+++ b/static/templates.json
@@ -915,6 +915,7 @@
   "website": "https://github.com/petender",
   "source": "https://github.com/petender/tdd-azd-foundry-healthcare-agents",
   "tags": ["ai-102", "msft", "aifoundry", "openai", "dotnet", "appservice", "aisearch", "keyvault", "appinsights"],
+  "industry": "Healthcare",
   "demoguide": "https://raw.githubusercontent.com/petender/tdd-azd-foundry-healthcare-agents/refs/heads/main/demoguide/demoguide.md",
   "deploytime": "8",
   "cost": "15.00"
@@ -927,6 +928,7 @@
   "website": "https://github.com/petender",
   "source": "https://github.com/petender/tdd-azd-ai-language-services",
   "tags": ["ai-102","ai-900","msft","appservice","cosmosdb","keyvault","loganalytics","azureai","dotnet"],
+  "industry": "Hospitality",
   "demoguide": "https://raw.githubusercontent.com/petender/tdd-azd-ai-language-services/refs/heads/main/demoguide/demoguide.md",
   "deploytime": "8",
   "cost": "12.00"
@@ -975,6 +977,7 @@
   "website": "https://github.com/petender",
   "source": "https://github.com/petender/tdd-azd-linux-vm-cosmosdb",
   "tags": ["az-104","msft","virtualmachine","cosmosdb","vnets","loganalytics","dotnet"],
+  "industry": "Logistics",
   "demoguide": "https://raw.githubusercontent.com/petender/tdd-azd-linux-vm-cosmosdb/refs/heads/main/demoguide/demoguide.md",
   "deploytime": "5",
   "cost": "10.00"


### PR DESCRIPTION
## Scenario Overview

Adds explicit `industry` metadata to catalog entries intentionally built for named business verticals.

**Catalog file**: `static/templates.json`
**Industries**: Healthcare, Hospitality, Logistics

## Catalog Changes

| Template | Industry |
| --- | --- |
| Azure AI Foundry Healthcare Agents | Healthcare |
| AI Language Services for Hospitality | Hospitality |
| Linux VM with Cosmos DB - Logistics | Logistics |

Ambiguous or general-purpose scenarios remain classified as `General`; this change does not infer industries from loosely related subject matter.

## Validation

- [x] Only `static/templates.json` changed
- [x] JSON editor diagnostics report no errors
- [x] `git diff --check` passed
- [x] No secrets, deployment state, or generated build output included

Repository scripts and tests were not run because the catalog instructions specify manual and visual validation for this file.