### PR TITLE
fix(gallery): remove duplicate BetterNotes entry

### DIFF
--- a/static/templates.json
+++ b/static/templates.json
@@ -741,7 +741,7 @@
   "title": "Azure Document Intelligence for your custom PDF, Docx or images text transformation",
   "description": "This scenario deploys an Azure Document Intelligence solution for extracting and transforming text from your custom PDF, Docx, or image files.",
   "preview": "./templates/images/test.png",
-  "authorUrl": "https://github.com/petender/",
+  "website": "https://github.com/petender",
   "author": "Peter De Tender",
   "source": "https://github.com/petender/azd-betternotes-ai",
   "demoguide": "https://raw.githubusercontent.com/petender/azd-betternotes-ai/refs/heads/main/demoguide/demoguide.md",
@@ -846,18 +846,6 @@
   "tags": ["msft", "dp-603", "dp-700", "msft", "fabric"],
   "cost": "6.00 (assuming pause after 4 hours)",
   "deploytime": "2" 
-  },
-  {
-  "title": "Azure AI Content Understanding (Document Intelligence) for your custom PDF, Docx or images text transformation",
-  "description": "A straightforward demo application in Azure App Service that utilizes Azure AI Content Understanding (Document Intelligence) to extract and transform text from custom PDF, Docx, or image files. The application provides a user-friendly interface for uploading documents and viewing the extracted information.",
-  "preview": "./templates/images/test.png",
-  "website": "https://github.com/petender",
-  "author": "Peter De Tender",
-  "source": "https://github.com/petender/azd-betternotes-ai",
-  "demoguide": "https://raw.githubusercontent.com/petender/azd-betternotes-ai/refs/heads/main/demoguide/demoguide.md",
-  "tags": ["msft", "ai-3002", "ai-102", "aifoundry"],
-  "cost": "1.00",
-  "deploytime": "4" 
   },
   {
   "title": "Azure Container Apps advanced features",


### PR DESCRIPTION
## Catalog Overview

Removes the later duplicate catalog object for `petender/azd-betternotes-ai` and retains the entry that matches the source repository's Azure Document Intelligence implementation.

## Metadata Update

- Replaces the retained entry's legacy `authorUrl` property with the supported `website` property.
- Removes the duplicate Azure AI Content Understanding entry.
- Leaves the retained source and demo-guide URLs unchanged.

## Validation

- [x] `static/templates.json` parses as a single JSON array.
- [x] All catalog source URLs are globally unique.
- [x] The BetterNotes source occurs exactly once.
- [x] No whitespace errors reported by `git diff --check`.
- [x] No scenario deployment changes are included.